### PR TITLE
feat: add support for sa-east-1

### DIFF
--- a/layerVersionsArm64.json
+++ b/layerVersionsArm64.json
@@ -9,5 +9,6 @@
 	"eu-central-1": "arn:aws:lambda:eu-central-1:580247275435:layer:LambdaInsightsExtension-Arm64:2",
 	"eu-west-1": "arn:aws:lambda:eu-west-1:580247275435:layer:LambdaInsightsExtension-Arm64:2",
 	"eu-west-2": "arn:aws:lambda:eu-west-2:580247275435:layer:LambdaInsightsExtension-Arm64:2",
-  "me-central-1": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:27"
+	"me-central-1": "arn:aws:lambda:me-central-1:732604637566:layer:LambdaInsightsExtension:27",
+	"sa-east-1": "arn:aws:lambda:sa-east-1:580247275435:layer:LambdaInsightsExtension-Arm64:21"
 }


### PR DESCRIPTION
The arn is from AWS docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-extension-versionsARM.html

To resolve error `Error: Unknown latest version for region 'sa-east-1'. Check the Lambda Insights documentation to get the list of currently supported versions` when packaging serverless for BR environment